### PR TITLE
Add List#replace()

### DIFF
--- a/src/tink/pure/List.hx
+++ b/src/tink/pure/List.hx
@@ -77,6 +77,9 @@ abstract List<T>(Node<T>) from Node<T> {
         new Node(1, value);
       else
         new Node(this.length + 1, value, [this]);
+        
+  public function replace(value:T, by:T):List<T>
+    return fromArray([for(v in iterator()) if(v == value) by else v]);
   
   public inline function exists(predicate:T->Bool) {
     var ret = false;

--- a/tests/ListTest.hx
+++ b/tests/ListTest.hx
@@ -51,6 +51,12 @@ class ListTest {
     return asserts.done();
   }
   
+  public function replace() {
+    var list = List.fromArray([1,2,1,3,1,4]);
+    list.replace(1, 5);
+    return assert(list.toArray().join(',') == '5,2,5,3,5,4');
+  }
+  
   #if tink_json
   public function json() {
     var list = List.fromArray([1,2,3,4]);


### PR DESCRIPTION
Replace a value in place while preserving the order.
I think there is a way to reuse the unchanged nodes, instead of creating each node again in `fromArray`