### PR TITLE
Detect array comprehension and avoid array copy in such case (fixes #19)

### DIFF
--- a/src/tink/pure/Vector.hx
+++ b/src/tink/pure/Vector.hx
@@ -87,7 +87,7 @@ abstract Vector<T>(Array<T>) to Vectorlike<T> {
           {expr: TVar({id: initId, name: name}, {expr: TArrayDecl([])})},
           {expr: TBlock(exprs)},
           {expr: TLocal({id: retId})},
-      ]) if(initId == retId && name.indexOf('`') != -1):
+      ]) if(initId == retId && name.charCodeAt(0) == '`'.code):
         macro @:pos(e.pos) @:privateAccess new tink.pure.Vector(${e});
       default:
         switch follow(t.t) {

--- a/src/tink/pure/Vector.hx
+++ b/src/tink/pure/Vector.hx
@@ -83,6 +83,12 @@ abstract Vector<T>(Array<T>) to Vectorlike<T> {
     return switch t.expr {
       case TArrayDecl(_):
         macro @:pos(e.pos) @:privateAccess new tink.pure.Vector(${e});
+      case TBlock([ // this is how the compiler transforms array comprehension syntax into typed exprs
+          {expr: TVar({id: initId, name: name}, {expr: TArrayDecl([])})},
+          {expr: TBlock(exprs)},
+          {expr: TLocal({id: retId})},
+      ]) if(initId == retId && name.indexOf('`') != -1):
+        macro @:pos(e.pos) @:privateAccess new tink.pure.Vector(${e});
       default:
         switch follow(t.t) {
           case TInst(_.get() => { pack: [], name: 'Array' }, _):

--- a/tests/VectorTest.hx
+++ b/tests/VectorTest.hx
@@ -37,4 +37,26 @@ class VectorTest {
     asserts.assert(a.fold((v, sum) -> sum + v, 0) == 10);
     return asserts.done();
   }
+  
+  public function comprehension() {
+    var a:Vector<Int> = [for(i in 0...10) if(i == 0) 10 else if(i < 4) i];
+    asserts.assert(a.length == 4);
+    asserts.assert(a[0] == 10);
+    asserts.assert(a[1] == 1);
+    asserts.assert(a[2] == 2);
+    asserts.assert(a[3] == 3);
+    return asserts.done();
+  }
+  
+  public function comprehensionEmulation() {
+    var b:Array<Int>;
+    var a:Vector<Int> = { // this block emulates the compiler generated exprs of an array comprehension
+      var v = [];
+      {b = v;}
+      v;
+    }
+    b.push(5);
+    asserts.assert(a.length == 0);
+    return asserts.done();
+  }
 }


### PR DESCRIPTION
This may be quite fragile as the generated expressions may be changed in the future. But in that case it is only the (no-copy) optimization which will fail but the functionality should be just fine.