### PR TITLE
Add minimal toString() to tink.pure.List making sure they don't get shown as null if empty

### DIFF
--- a/src/tink/pure/List.hx
+++ b/src/tink/pure/List.hx
@@ -173,6 +173,9 @@ abstract List<T>(Node<T>) from Node<T> {
 
     return ret;
   }
+
+  public function toString():String
+      return this == null ? '()' : Std.string(this);
 }
 
 @:generic private class Node<T> {


### PR DESCRIPTION
tracing pure lists can be confusing when empty (they show as `null`)
To avoid confusion and save time, we propose showing empty lists as `()`.

I think it will help beginners (especially those who work with coconut,
e.g. when tracing a field of a chain of computed that shows `null` where
it's supposed to show empty list, my instinct is to jump at debugging)

remains to see if there is any drawback